### PR TITLE
Add appveyor.yml for automatic builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: '{build}'
+
+image:
+- Visual Studio 2017
+- Ubuntu1804
+
+install:
+- cmd: set PATH=%PATH%;C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin
+- sh: sudo apt-get update && sudo apt-get -y install build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
+
+build_script:
+- cmd: mingw32-make -j 6 -C bsnes
+- sh: make -j 2 -C bsnes
+
+after_build:
+- cmd: cd bsnes/out && 7z a ../../bsnes_hd.zip bsnes.exe ../../icarus/Database ../../icarus/Firmware ../../LICENSE ../../README.md
+- sh: cd bsnes/out && 7z a ../../bsnes_hd.zip bsnes ../../LICENSE ../../README.md
+
+test: off
+
+artifacts:
+- path: bsnes_hd.zip


### PR DESCRIPTION
Merging this alone will not make AppVeyor work. You will need to create an account, and add the project.
The link will be something like https://ci.appveyor.com/project/DerKoun/bsnes-hd/
This has Windows and Linux (untested) builds.