### PR TITLE
Corrected valid extensions to fix archive loading of GB/GBC

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -808,7 +808,7 @@ RETRO_API void retro_get_system_info(retro_system_info *info)
 	info->library_name     = Emulator::Name;
 	info->library_version  = Emulator::Version;
 	info->need_fullpath    = true;
-	info->valid_extensions = "smc|sfc";
+	info->valid_extensions = "smc|sfc|gb|gbc";
 	info->block_extract = false;
 }
 


### PR DESCRIPTION
Currently loading GB/GBC files from within an archive in this core throws an error and doesn't extract the file to the cache directory. The game still runs, but it interferes with all operations relying on a cached copy of the file. Adding gb and gbc to supported extensions remedies this issue.