### PR TITLE
[Libretro] Upgrade Core Options to v1.3 with sublabels and translation support

### DIFF
--- a/bsnes/target-libretro/libretro-common/include/retro_inline.h
+++ b/bsnes/target-libretro/libretro-common/include/retro_inline.h
@@ -1,0 +1,39 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (retro_inline.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_INLINE_H
+#define __LIBRETRO_SDK_INLINE_H
+
+#ifndef INLINE
+
+#if defined(_WIN32) || defined(__INTEL_COMPILER)
+#define INLINE __inline
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
+#define INLINE inline
+#elif defined(__GNUC__)
+#define INLINE __inline__
+#else
+#define INLINE
+#endif
+
+#endif
+#endif

--- a/bsnes/target-libretro/libretro.h
+++ b/bsnes/target-libretro/libretro.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 The RetroArch team
+/* Copyright (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this libretro API header (libretro.h).
@@ -69,7 +69,7 @@ extern "C" {
 #      endif
 #    endif
 #  else
-#      if defined(__GNUC__) && __GNUC__ >= 4 && !defined(__CELLOS_LV2__)
+#      if defined(__GNUC__) && __GNUC__ >= 4
 #        define RETRO_API RETRO_CALLCONV __attribute__((__visibility__("default")))
 #      else
 #        define RETRO_API RETRO_CALLCONV
@@ -278,6 +278,11 @@ enum retro_language
    RETRO_LANGUAGE_ARABIC              = 16,
    RETRO_LANGUAGE_GREEK               = 17,
    RETRO_LANGUAGE_TURKISH             = 18,
+   RETRO_LANGUAGE_SLOVAK              = 19,
+   RETRO_LANGUAGE_PERSIAN             = 20,
+   RETRO_LANGUAGE_HEBREW              = 21,
+   RETRO_LANGUAGE_ASTURIAN            = 22,
+   RETRO_LANGUAGE_FINNISH             = 23,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -708,6 +713,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --
@@ -1087,10 +1095,10 @@ enum retro_mod
 
 #define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                             /* float * --
-                                            * Float value that lets us know what target refresh rate 
+                                            * Float value that lets us know what target refresh rate
                                             * is curently in use by the frontend.
                                             *
-                                            * The core can use the returned value to set an ideal 
+                                            * The core can use the returned value to set an ideal
                                             * refresh rate/framerate.
                                             */
 
@@ -1098,7 +1106,7 @@ enum retro_mod
                                             /* bool * --
                                             * Boolean value that indicates whether or not the frontend supports
                                             * input bitmasks being returned by retro_input_state_t. The advantage
-                                            * of this is that retro_input_state_t has to be only called once to 
+                                            * of this is that retro_input_state_t has to be only called once to
                                             * grab all button states instead of multiple times.
                                             *
                                             * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
@@ -1117,7 +1125,7 @@ enum retro_mod
                                             * This may be still be done regardless of the core options
                                             * interface version.
                                             *
-                                            * If version is 1 however, core options may instead be set by
+                                            * If version is >= 1 however, core options may instead be set by
                                             * passing an array of retro_core_option_definition structs to
                                             * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
@@ -1132,8 +1140,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1194,8 +1202,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1244,6 +1252,140 @@ enum retro_mod
                                             *
                                             * Note that all core option variables will be set visible by
                                             * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER 56
+                                           /* unsigned * --
+                                            *
+                                            * Allows an implementation to ask frontend preferred hardware
+                                            * context to use. Core should use this information to deal
+                                            * with what specific context to request with SET_HW_RENDER.
+                                            *
+                                            * 'data' points to an unsigned variable
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION 57
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the disk control
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, the disk control interface is defined by passing
+                                            * a struct of type retro_disk_control_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+                                            * This may be still be done regardless of the disk control
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, the disk control interface may
+                                            * instead be defined by passing a struct of type
+                                            * retro_disk_control_ext_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
+                                            * This allows the core to provide additional information about
+                                            * disk images to the frontend and/or enables extra
+                                            * disk control functionality by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE 58
+                                           /* const struct retro_disk_control_ext_callback * --
+                                            * Sets an interface which frontend can use to eject and insert
+                                            * disk images, and also obtain information about individual
+                                            * disk image files registered by the core.
+                                            * This is used for games which consist of multiple images and
+                                            * must be manually swapped out by the user (e.g. PSX, floppy disk
+                                            * based systems).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the message
+                                            * interface supported by the frontend. If callback returns
+                                            * false, API version is assumed to be 0.
+                                            *
+                                            * In legacy code, messages may be displayed in an
+                                            * implementation-specific manner by passing a struct
+                                            * of type retro_message to RETRO_ENVIRONMENT_SET_MESSAGE.
+                                            * This may be still be done regardless of the message
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, messages may instead be
+                                            * displayed by passing a struct of type retro_message_ext
+                                            * to RETRO_ENVIRONMENT_SET_MESSAGE_EXT. This allows the
+                                            * core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MESSAGE_EXT 60
+                                           /* const struct retro_message_ext * --
+                                            * Sets a message to be displayed in an implementation-specific
+                                            * manner for a certain amount of 'frames'. Additionally allows
+                                            * the core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            * Should not be used for trivial messages, which should simply be
+                                            * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
+                                            * fallback, stderr).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
+                                           /* unsigned * --
+                                            * Unsigned value is the number of active input devices
+                                            * provided by the frontend. This may change between
+                                            * frames, but will remain constant for the duration
+                                            * of each frame.
+                                            * If callback returns true, a core need not poll any
+                                            * input device with an index greater than or equal to
+                                            * the number of active devices.
+                                            * If callback returns false, the number of active input
+                                            * devices is unknown. In this case, all input devices
+                                            * should be considered active.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
                                             */
 
 /* VFS functionality */
@@ -1922,6 +2064,10 @@ enum retro_sensor_action
 {
    RETRO_SENSOR_ACCELEROMETER_ENABLE = 0,
    RETRO_SENSOR_ACCELEROMETER_DISABLE,
+   RETRO_SENSOR_GYROSCOPE_ENABLE,
+   RETRO_SENSOR_GYROSCOPE_DISABLE,
+   RETRO_SENSOR_ILLUMINANCE_ENABLE,
+   RETRO_SENSOR_ILLUMINANCE_DISABLE,
 
    RETRO_SENSOR_DUMMY = INT_MAX
 };
@@ -1930,6 +2076,10 @@ enum retro_sensor_action
 #define RETRO_SENSOR_ACCELEROMETER_X 0
 #define RETRO_SENSOR_ACCELEROMETER_Y 1
 #define RETRO_SENSOR_ACCELEROMETER_Z 2
+#define RETRO_SENSOR_GYROSCOPE_X 3
+#define RETRO_SENSOR_GYROSCOPE_Y 4
+#define RETRO_SENSOR_GYROSCOPE_Z 5
+#define RETRO_SENSOR_ILLUMINANCE 6
 
 typedef bool (RETRO_CALLCONV *retro_set_sensor_state_t)(unsigned port,
       enum retro_sensor_action action, unsigned rate);
@@ -2127,6 +2277,30 @@ struct retro_frame_time_callback
    retro_usec_t reference;
 };
 
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
+};
+
 /* Pass this to retro_video_refresh_t if rendering to hardware.
  * Passing NULL to retro_video_refresh_t is still a frame dupe as normal.
  * */
@@ -2287,7 +2461,8 @@ struct retro_keyboard_callback
    retro_keyboard_event_t callback;
 };
 
-/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE &
+ * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
  * Should be set for implementations which can swap out multiple disk
  * images in runtime.
  *
@@ -2345,6 +2520,53 @@ typedef bool (RETRO_CALLCONV *retro_replace_image_index_t)(unsigned index,
  * with replace_image_index. */
 typedef bool (RETRO_CALLCONV *retro_add_image_index_t)(void);
 
+/* Sets initial image to insert in drive when calling
+ * core_load_game().
+ * Since we cannot pass the initial index when loading
+ * content (this would require a major API change), this
+ * is set by the frontend *before* calling the core's
+ * retro_load_game()/retro_load_game_special() implementation.
+ * A core should therefore cache the index/path values and handle
+ * them inside retro_load_game()/retro_load_game_special().
+ * - If 'index' is invalid (index >= get_num_images()), the
+ *   core should ignore the set value and instead use 0
+ * - 'path' is used purely for error checking - i.e. when
+ *   content is loaded, the core should verify that the
+ *   disk specified by 'index' has the specified file path.
+ *   This is to guard against auto selecting the wrong image
+ *   if (for example) the user should modify an existing M3U
+ *   playlist. We have to let the core handle this because
+ *   set_initial_image() must be called before loading content,
+ *   i.e. the frontend cannot access image paths in advance
+ *   and thus cannot perform the error check itself.
+ *   If set path and content path do not match, the core should
+ *   ignore the set 'index' value and instead use 0
+ * Returns 'false' if index or 'path' are invalid, or core
+ * does not support this functionality
+ */
+typedef bool (RETRO_CALLCONV *retro_set_initial_image_t)(unsigned index, const char *path);
+
+/* Fetches the path of the specified disk image file.
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or path is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_path_t)(unsigned index, char *path, size_t len);
+
+/* Fetches a core-provided 'label' for the specified disk
+ * image file. In the simplest case this may be a file name
+ * (without extension), but for cores with more complex
+ * content requirements information may be provided to
+ * facilitate user disk swapping - for example, a core
+ * running floppy-disk-based content may uniquely label
+ * save disks, data disks, level disks, etc. with names
+ * corresponding to in-game disk change prompts (so the
+ * frontend can provide better user guidance than a 'dumb'
+ * disk index value).
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or label is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_label_t)(unsigned index, char *label, size_t len);
+
 struct retro_disk_control_callback
 {
    retro_set_eject_state_t set_eject_state;
@@ -2356,6 +2578,27 @@ struct retro_disk_control_callback
 
    retro_replace_image_index_t replace_image_index;
    retro_add_image_index_t add_image_index;
+};
+
+struct retro_disk_control_ext_callback
+{
+   retro_set_eject_state_t set_eject_state;
+   retro_get_eject_state_t get_eject_state;
+
+   retro_get_image_index_t get_image_index;
+   retro_set_image_index_t set_image_index;
+   retro_get_num_images_t  get_num_images;
+
+   retro_replace_image_index_t replace_image_index;
+   retro_add_image_index_t add_image_index;
+
+   /* NOTE: Frontend will only attempt to record/restore
+    * last used disk index if both set_initial_image()
+    * and get_image_path() are implemented */
+   retro_set_initial_image_t set_initial_image; /* Optional - may be NULL */
+
+   retro_get_image_path_t get_image_path;       /* Optional - may be NULL */
+   retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
 enum retro_pixel_format
@@ -2388,6 +2631,104 @@ struct retro_message
    unsigned    frames;     /* Duration in frames of message. */
 };
 
+enum retro_message_target
+{
+   RETRO_MESSAGE_TARGET_ALL = 0,
+   RETRO_MESSAGE_TARGET_OSD,
+   RETRO_MESSAGE_TARGET_LOG
+};
+
+enum retro_message_type
+{
+   RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
+   RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+   RETRO_MESSAGE_TYPE_STATUS,
+   RETRO_MESSAGE_TYPE_PROGRESS
+};
+
+struct retro_message_ext
+{
+   /* Message string to be displayed/logged */
+   const char *msg;
+   /* Duration (in ms) of message when targeting the OSD */
+   unsigned duration;
+   /* Message priority when targeting the OSD
+    * > When multiple concurrent messages are sent to
+    *   the frontend and the frontend does not have the
+    *   capacity to display them all, messages with the
+    *   *highest* priority value should be shown
+    * > There is no upper limit to a message priority
+    *   value (within the bounds of the unsigned data type)
+    * > In the reference frontend (RetroArch), the same
+    *   priority values are used for frontend-generated
+    *   notifications, which are typically assigned values
+    *   between 0 and 3 depending upon importance */
+   unsigned priority;
+   /* Message logging level (info, warn, error, etc.) */
+   enum retro_log_level level;
+   /* Message destination: OSD, logging interface or both */
+   enum retro_message_target target;
+   /* Message 'type' when targeting the OSD
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION: Specifies that a
+    *   message should be handled in identical fashion to
+    *   a standard frontend-generated notification
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION_ALT: Specifies that
+    *   message is a notification that requires user attention
+    *   or action, but that it should be displayed in a manner
+    *   that differs from standard frontend-generated notifications.
+    *   This would typically correspond to messages that should be
+    *   displayed immediately (independently from any internal
+    *   frontend message queue), and/or which should be visually
+    *   distinguishable from frontend-generated notifications.
+    *   For example, a core may wish to inform the user of
+    *   information related to a disk-change event. It is
+    *   expected that the frontend itself may provide a
+    *   notification in this case; if the core sends a
+    *   message of type RETRO_MESSAGE_TYPE_NOTIFICATION, an
+    *   uncomfortable 'double-notification' may occur. A message
+    *   of RETRO_MESSAGE_TYPE_NOTIFICATION_ALT should therefore
+    *   be presented such that visual conflict with regular
+    *   notifications does not occur
+    * > RETRO_MESSAGE_TYPE_STATUS: Indicates that message
+    *   is not a standard notification. This typically
+    *   corresponds to 'status' indicators, such as a core's
+    *   internal FPS, which are intended to be displayed
+    *   either permanently while a core is running, or in
+    *   a manner that does not suggest user attention or action
+    *   is required. 'Status' type messages should therefore be
+    *   displayed in a different on-screen location and in a manner
+    *   easily distinguishable from both standard frontend-generated
+    *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * > RETRO_MESSAGE_TYPE_PROGRESS: Indicates that message reports
+    *   the progress of an internal core task. For example, in cases
+    *   where a core itself handles the loading of content from a file,
+    *   this may correspond to the percentage of the file that has been
+    *   read. Alternatively, an audio/video playback core may use a
+    *   message of type RETRO_MESSAGE_TYPE_PROGRESS to display the current
+    *   playback position as a percentage of the runtime. 'Progress' type
+    *   messages should therefore be displayed as a literal progress bar,
+    *   where:
+    *   - 'retro_message_ext.msg' is the progress bar title/label
+    *   - 'retro_message_ext.progress' determines the length of
+    *     the progress bar
+    * NOTE: Message type is a *hint*, and may be ignored
+    * by the frontend. If a frontend lacks support for
+    * displaying messages via alternate means than standard
+    * frontend-generated notifications, it will treat *all*
+    * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
+   enum retro_message_type type;
+   /* Task progress when targeting the OSD and message is
+    * of type RETRO_MESSAGE_TYPE_PROGRESS
+    * > -1:    Unmetered/indeterminate
+    * > 0-100: Current progress percentage
+    * NOTE: Since message type is a hint, a frontend may ignore
+    * progress values. Where relevant, a core should therefore
+    * include progress percentage within the message string,
+    * such that the message intent remains clear when displayed
+    * as a standard frontend-generated notification */
+   int8_t progress;
+};
+
 /* Describes how the libretro implementation maps a libretro input bind
  * to its internal input system through a human readable string.
  * This string can be used to better let a user configure input. */
@@ -2408,7 +2749,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */
@@ -2501,7 +2842,21 @@ struct retro_core_option_display
    bool visible;
 };
 
-/* Maximum number of values permitted for a core option */
+/* Maximum number of values permitted for a core option
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value
@@ -2591,6 +2946,47 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
 };
 
 /* Callbacks */

--- a/bsnes/target-libretro/libretro_core_options.h
+++ b/bsnes/target-libretro/libretro_core_options.h
@@ -1,0 +1,1032 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "libretro.h"
+#include "libretro-common/include/retro_inline.h"
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_definition option_defs_us[] = {
+   {
+      "bsnes_video_luminance",
+      "Color Adjustment - Luminance",
+      "Adjusts the luminance level of the video output.",
+      {
+         { "0",   NULL },
+         { "10",  NULL },
+         { "20",  NULL },
+         { "30",  NULL },
+         { "40",  NULL },
+         { "50",  NULL },
+         { "60",  NULL },
+         { "70",  NULL },
+         { "80",  NULL },
+         { "90",  NULL },
+         { "100", NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_video_saturation",
+      "Color Adjustment - Saturation",
+      "Adjusts the saturation level of the video output.",
+      {
+         { "0",   NULL },
+         { "10",  NULL },
+         { "20",  NULL },
+         { "30",  NULL },
+         { "40",  NULL },
+         { "50",  NULL },
+         { "60",  NULL },
+         { "70",  NULL },
+         { "80",  NULL },
+         { "90",  NULL },
+         { "100", NULL },
+         { "110", NULL },
+         { "120", NULL },
+         { "130", NULL },
+         { "140", NULL },
+         { "150", NULL },
+         { "160", NULL },
+         { "170", NULL },
+         { "180", NULL },
+         { "190", NULL },
+         { "200", NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_video_gamma",
+      "Color Adjustment - Gamma",
+      "Adjusts the gamma level of the video output.",
+      {
+         { "100", NULL },
+         { "110", NULL },
+         { "120", NULL },
+         { "130", NULL },
+         { "140", NULL },
+         { "150", NULL },
+         { "160", NULL },
+         { "170", NULL },
+         { "180", NULL },
+         { "190", NULL },
+         { "200", NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_video_aspectcorrection",
+      "Pixel Aspect Correction",
+      "Determines whether the internal pixel aspect should be corrected using 4:3 as the basis, or preserved as-is with the original 8:7 proportion. This specifically affects the ratio of the pixels and should not be confused with the widescreen-related options.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_ppu_show_overscan",
+      "Crop Overscan",
+      "Crops the borders at the top and bottom of the screen, typically unused by games and hidden by the bezel of a standard-definition television, by the specified amount of pixels.",
+      {
+         { "OFF",     "12 pixels" },
+         { "ON",      "8 pixels"  },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_blur_emulation",
+      "Blur Emulation",
+      "Simulates the limited horizontal resolution of SDTVs by blurring together horizontally-adjacent pixels. Some games depend on this to emulate a transparency effect.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_hotfixes",
+      "Hotfixes",
+      "Even commercially licensed and officially released software sometimes shipped with bugs. This option will correct certain issues that occurred even on real hardware.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_entropy",
+      "Entropy (randomization)",
+      "Determines the level of randomization of the memory and registers. If set to None, all memory and registers are initialized to constant values at startup. Low randomization provides the most accurate representation of a real system. High randomizes as much as possible.",
+      {
+         { "Low",  NULL },
+         { "High", NULL },
+         { "None", NULL },
+         { NULL, NULL },
+      },
+      "Low"
+   },
+   {
+      "bsnes_cpu_overclock",
+      "Overclocking - CPU",
+      "Overclocks or downclocks the CPU. Setting this value above 100% may help reduce loading times and remove slowdown. Use with caution as it may also cause certain games to crash or exhibit issues.",
+      {
+         { "10",  "10%"  },
+         { "20",  "20%"  },
+         { "30",  "30%"  },
+         { "40",  "40%"  },
+         { "50",  "50%"  },
+         { "60",  "60%"  },
+         { "70",  "70%"  },
+         { "80",  "80%"  },
+         { "90",  "90%"  },
+         { "100", "100%" },
+         { "110", "110%" },
+         { "120", "120%" },
+         { "130", "130%" },
+         { "140", "140%" },
+         { "150", "150%" },
+         { "160", "160%" },
+         { "170", "170%" },
+         { "180", "180%" },
+         { "190", "190%" },
+         { "200", "200%" },
+         { "210", "210%" },
+         { "220", "220%" },
+         { "230", "230%" },
+         { "240", "240%" },
+         { "250", "250%" },
+         { "260", "260%" },
+         { "270", "270%" },
+         { "280", "280%" },
+         { "290", "290%" },
+         { "300", "300%" },
+         { "310", "310%" },
+         { "320", "320%" },
+         { "330", "330%" },
+         { "340", "340%" },
+         { "350", "350%" },
+         { "360", "360%" },
+         { "370", "370%" },
+         { "380", "380%" },
+         { "390", "390%" },
+         { "400", "400%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_cpu_fastmath",
+      "CPU Fast Math",
+      "CPU multiplication and division take time to complete on a real SNES. Older emulators did not simulate these delays and provided results immediately. Some older ROM hacks do not wait for math operations to complete and need this hack.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_cpu_sa1_overclock",
+      "Overclocking - SA-1 Coprocessor",
+      "Overclocks or downclocks the Super Accelerator 1 (SA-1) chip. Setting this value above 100% may help obtain higher performance in games that support the SA-1 chip. Use with caution as it may also cause certain games to crash or exhibit issues.",
+      {
+         { "10",  "10%"  },
+         { "20",  "20%"  },
+         { "30",  "30%"  },
+         { "40",  "40%"  },
+         { "50",  "50%"  },
+         { "60",  "60%"  },
+         { "70",  "70%"  },
+         { "80",  "80%"  },
+         { "90",  "90%"  },
+         { "100", "100%" },
+         { "110", "110%" },
+         { "120", "120%" },
+         { "130", "130%" },
+         { "140", "140%" },
+         { "150", "150%" },
+         { "160", "160%" },
+         { "170", "170%" },
+         { "180", "180%" },
+         { "190", "190%" },
+         { "200", "200%" },
+         { "210", "210%" },
+         { "220", "220%" },
+         { "230", "230%" },
+         { "240", "240%" },
+         { "250", "250%" },
+         { "260", "260%" },
+         { "270", "270%" },
+         { "280", "280%" },
+         { "290", "290%" },
+         { "300", "300%" },
+         { "310", "310%" },
+         { "320", "320%" },
+         { "330", "330%" },
+         { "340", "340%" },
+         { "350", "350%" },
+         { "360", "360%" },
+         { "370", "370%" },
+         { "380", "380%" },
+         { "390", "390%" },
+         { "400", "400%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_cpu_sfx_overclock",
+      "Overclocking - SuperFX Coprocessor",
+      "Overclocks or downclocks the SuperFX coprocessor. Setting this value above 100% may help obtain higher performance in games that support the SuperFX. Use with caution as it may also cause certain games to crash or exhibit issues.",
+      {
+         { "10",  "10%"  },
+         { "20",  "20%"  },
+         { "30",  "30%"  },
+         { "40",  "40%"  },
+         { "50",  "50%"  },
+         { "60",  "60%"  },
+         { "70",  "70%"  },
+         { "80",  "80%"  },
+         { "90",  "90%"  },
+         { "100", "100%" },
+         { "110", "110%" },
+         { "120", "120%" },
+         { "130", "130%" },
+         { "140", "140%" },
+         { "150", "150%" },
+         { "160", "160%" },
+         { "170", "170%" },
+         { "180", "180%" },
+         { "190", "190%" },
+         { "200", "200%" },
+         { "210", "210%" },
+         { "220", "220%" },
+         { "230", "230%" },
+         { "240", "240%" },
+         { "250", "250%" },
+         { "260", "260%" },
+         { "270", "270%" },
+         { "280", "280%" },
+         { "290", "290%" },
+         { "300", "300%" },
+         { "310", "310%" },
+         { "320", "320%" },
+         { "330", "330%" },
+         { "340", "340%" },
+         { "350", "350%" },
+         { "360", "360%" },
+         { "370", "370%" },
+         { "380", "380%" },
+         { "390", "390%" },
+         { "400", "400%" },
+         { "410", "410%" },
+         { "420", "420%" },
+         { "430", "430%" },
+         { "440", "440%" },
+         { "450", "450%" },
+         { "460", "460%" },
+         { "470", "470%" },
+         { "480", "480%" },
+         { "490", "490%" },
+         { "500", "500%" },
+         { "510", "510%" },
+         { "520", "520%" },
+         { "530", "530%" },
+         { "540", "540%" },
+         { "550", "550%" },
+         { "560", "560%" },
+         { "570", "570%" },
+         { "580", "580%" },
+         { "590", "590%" },
+         { "600", "600%" },
+         { "610", "610%" },
+         { "620", "620%" },
+         { "630", "630%" },
+         { "640", "640%" },
+         { "650", "650%" },
+         { "660", "660%" },
+         { "670", "670%" },
+         { "680", "680%" },
+         { "690", "690%" },
+         { "700", "700%" },
+         { "710", "710%" },
+         { "720", "720%" },
+         { "730", "730%" },
+         { "740", "740%" },
+         { "750", "750%" },
+         { "760", "760%" },
+         { "770", "770%" },
+         { "780", "780%" },
+         { "790", "790%" },
+         { "800", "800%" },
+         { NULL, NULL },
+      },
+      "100"
+   },
+   {
+      "bsnes_ppu_fast",
+      "PPU (Video) - Fast Mode",
+      "Enables faster emulation of the PPU at the cost of a minor reduction of accuracy. It is recommended to leave this active.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_ppu_deinterlace",
+      "PPU (Video) - Deinterlace",
+      "Deinterlaces all games by rendering internally at 480p. Performance penalty is almost non-existent, so it is recommended to leave this active.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_ppu_no_sprite_limit",
+      "PPU (Video) - No Sprite Limit",
+      "Removes any limit to the number of sprites that can be drawn simultaneously on screen. May cause issues with certain games.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_ppu_no_vram_blocking",
+      "PPU (Video) - No VRAM Blocking",
+      "Emulates a bug in older releases of ZSNES and Snes9x, where VRAM blocking was not emulated. A few older ROM hacks relied on this behavior and will render graphics incorrectly if not enabled. This option is extremely inaccurate and hurts PPU speed, so it is recommended to leave it disabled unless you need to play a game that is otherwise incompatible with this core.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_dsp_fast",
+      "DSP (Audio) - Fast Mode",
+      "Enables faster emulation of the DSP at the cost of a minor reduction of accuracy. It is recommended to leave this active.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_dsp_cubic",
+      "DSP (Audio) - Cubic Interpolation",
+      "Applies cubic interpolation to the sound, preserving more of the high range.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_dsp_echo_shadow",
+      "DSP (Audio) - Echo Shadow RAM",
+      "Emulates a bug in ZSNES where echo RAM was treated as separate from APU RAM. Many older ROM hacks for Super Mario World relied on this behavior and will crash without enabling this. This option is extremely inaccurate and should not be enabled unless required.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_coprocessor_delayed_sync",
+      "Coprocessors - Fast Mode",
+      "Enables faster emulation of the coprocessors at the cost of a minor reduction of accuracy. It is recommended to leave this active.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_coprocessor_prefer_hle",
+      "Coprocessors - Prefer HLE",
+      "When this option is enabled, less accurate HLE emulation will always be used when available. If disabled, HLE will only be used when LLE firmware is missing.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+         { NULL, NULL },
+      },
+      "ON"
+   },
+   {
+      "bsnes_sgb_bios",
+      "Preferred Super Game Boy BIOS (Requires Restart)",
+      "Allows to choose the preferred Super Game Boy BIOS to be used with compatible titles. Requires a restart to take effect.",
+      {
+         { "SGB1.sfc", "Super Game Boy (SGB1.sfc)"   },
+         { "SGB2.sfc", "Super Game Boy 2 (SGB2.sfc)" },
+         { NULL, NULL },
+      },
+      "SGB1.sfc"
+   },
+   {
+      "bsnes_run_ahead_frames",
+      "Internal Run-Ahead",
+      "Simulates the system ahead of time and rolls back to reduce input latency. Has very high system requirements.",
+      {
+         { "OFF", "disabled" },
+         { "1",   "1 frame"  },
+         { "2",   "2 frames" },
+         { "3",   "3 frames" },
+         { "4",   "4 frames" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_ips_headered",
+      "Expect Headered ROMs for IPS Patches",
+      "Defines whether the core should always expect headered ROMs when using IPS patches.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+      },
+      "OFF"
+   },
+   {
+      "bsnes_mode7_scale",
+      "HD Mode 7 - Scale",
+      "Allows to increase the horizontal and vertical resolution of the Mode 7 graphics used in certain games. If disabled, the original unaltered Mode 7 graphics will be used.",
+      {
+         { "disable", "disabled"    },
+         { "1x",      "240p (1x)"   },
+         { "2x",      "480p (2x)"   },
+         { "3x",      "720p (3x)"   },
+         { "4x",      "960p (4x)"   },
+         { "5x",      "1200p (5x)"  },
+         { "6x",      "1440p (6x)"  },
+         { "7x",      "1680p (7x)"  },
+         { "8x",      "1920p (8x)"  },
+         { "9x",      "2160p (9x)"  },
+         { "10x",     "2400p (10x)" },
+         { NULL, NULL },
+      },
+      "2x"
+   },
+   {
+      "bsnes_mode7_perspective",
+      "HD Mode 7 - Perspective Correction",
+      "Corrects the perspective of the Mode 7 graphics used in certain games by working around some limitations of the integer math used by the SNES.",
+      {
+         { "auto (wide)",   "Auto (Wide)"   },
+         { "auto (medium)", "Auto (Medium)" },
+         { "auto (narrow)", "Auto (Narrow)" },
+         { "on (wide)",     "ON (Wide)"     },
+         { "on (medium)",   "ON (Medium)"   },
+         { "on (narrow)",   "ON (Narrow)"   },
+         { "off",           "disabled"      },
+         { NULL, NULL },
+      },
+      "auto (wide)"
+   },
+   {
+      "bsnes_mode7_supersample",
+      "HD Mode 7 - Supersampling",
+      "Allows to supersample the Mode 7 graphics used in certain games by the specified amount. Combined with higher Mode 7 scale factors, it produces an effect similar to anti-aliasing.",
+      {
+         { "none", "disabled" },
+         { "2x",  NULL },
+         { "3x",  NULL },
+         { "4x",  NULL },
+         { "5x",  NULL },
+         { "6x",  NULL },
+         { "7x",  NULL },
+         { "8x",  NULL },
+         { "9x",  NULL },
+         { "10x", NULL },
+         { NULL, NULL },
+      },
+      "none"
+   },
+   {
+      "bsnes_mode7_mosaic",
+      "HD Mode 7 - HD->SD Mosaic",
+      "Determines whether and how the mosaic effect should be shown with Mode 7 graphics. 'Non-HD' uses classic Mode 7 with the mosaic effect applied, but disables HD and widescreen. 'Ignore' disregards the mosaic effect entirely. '1x Scale' provides a good compromise between the other two options.",
+      {
+         { "non-HD",   "Non-HD"   },
+         { "ignore",   "Ignore"   },
+         { "1x scale", "1x Scale" },
+      },
+      "1x scale"
+   },
+   {
+      "bsnes_mode7_bgGrad",
+      "HD Background Color Radius",
+      "Defines the amount of neighboring lines used to smooth color gradients that are applied to the frame.",
+      {
+         { "1", NULL       },
+         { "2", NULL       },
+         { "3", NULL       },
+         { "4", NULL       },
+         { "5", NULL       },
+         { "6", NULL       },
+         { "7", NULL       },
+         { "8", NULL       },
+         { "0", "disabled" },
+         { NULL, NULL },
+      },
+      "4"
+   },
+   {
+      "bsnes_mode7_windRad",
+      "HD Windowing (Experimental)",
+      "Defines the amount of neighboring lines used to smooth window effects, such as iris transitions, shadows or spell effects.",
+      {
+         { "1", NULL       },
+         { "2", NULL       },
+         { "3", NULL       },
+         { "4", NULL       },
+         { "5", NULL       },
+         { "6", NULL       },
+         { "7", NULL       },
+         { "8", NULL       },
+         { "0", "disabled" },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "bsnes_mode7_wsMode",
+      "Widescreen Mode",
+      "Enables experimental widescreen functionality.",
+      {
+         { "Mode 7", "Only for Mode 7 scenes" },
+         { "all",    "Enable for all scenes"  },
+         { "none",   "disabled"               },
+         { NULL, NULL },
+      },
+      "Mode 7"
+   },
+   {
+      "bsnes_mode7_widescreen",
+      "Widescreen - Aspect Ratio",
+      "Defines the content aspect ratio used when Widescreen Mode is enabled.",
+      {
+         { "16:9",  NULL },
+         { "16:10", NULL },
+         { "21:9",  NULL },
+         { "2:1",   NULL },
+         { "4:3",   NULL },
+         { "none",  "disabled" },
+         { NULL, NULL },
+      },
+      "16:9"
+   },
+   {
+      "bsnes_mode7_wsbg1",
+      "Widescreen - Background Layer 1",
+      "Determines how Widescreen Mode should be applied to Background Layer 1.",
+      {
+         { "on",                 "enabled"                                    },
+         { "auto horizontal",    "Enable if screen-wide and X position is 0"  },
+         { "auto horz and vert", "Enable if screen-wide and XY position is 0" },
+         { "above line 40",      "Enable above line 40"                       },
+         { "below line 40",      "Enable below line 40"                       },
+         { "above line 80",      "Enable above line 80"                       },
+         { "below line 80",      "Enable below line 80"                       },
+         { "above line 120",     "Enable above line 120"                      },
+         { "below line 120",     "Enable below line 120"                      },
+         { "above line 160",     "Enable above line 160"                      },
+         { "below line 160",     "Enable below line 160"                      },
+         { "above line 200",     "Enable above line 200"                      },
+         { "below line 200",     "Enable below line 200"                      },
+         { "crop edges",         "Hide lateral 8 pixels"                      },
+         { "auto crop edges",    "Hide lateral 8 black pixels"                },
+         { "off",                "Disable widescreen for this layer"          },
+         { "disable entirely",   "Hide layer entirely"                        },
+         { NULL, NULL },
+      },
+      "auto horz and vert"
+   },
+   {
+      "bsnes_mode7_wsbg2",
+      "Widescreen - Background Layer 2",
+      "Determines how Widescreen Mode should be applied to Background Layer 2.",
+      {
+         { "on",                 "enabled"                                    },
+         { "auto horizontal",    "Enable if screen-wide and X position is 0"  },
+         { "auto horz and vert", "Enable if screen-wide and XY position is 0" },
+         { "above line 40",      "Enable above line 40"                       },
+         { "below line 40",      "Enable below line 40"                       },
+         { "above line 80",      "Enable above line 80"                       },
+         { "below line 80",      "Enable below line 80"                       },
+         { "above line 120",     "Enable above line 120"                      },
+         { "below line 120",     "Enable below line 120"                      },
+         { "above line 160",     "Enable above line 160"                      },
+         { "below line 160",     "Enable below line 160"                      },
+         { "above line 200",     "Enable above line 200"                      },
+         { "below line 200",     "Enable below line 200"                      },
+         { "crop edges",         "Hide lateral 8 pixels"                      },
+         { "auto crop edges",    "Hide lateral 8 black pixels"                },
+         { "off",                "Disable widescreen for this layer"          },
+         { "disable entirely",   "Hide layer entirely"                        },
+         { NULL, NULL },
+      },
+      "auto horz and vert"
+   },
+   {
+      "bsnes_mode7_wsbg3",
+      "Widescreen - Background Layer 3",
+      "Determines how Widescreen Mode should be applied to Background Layer 3.",
+      {
+         { "on",                 "enabled"                                    },
+         { "auto horizontal",    "Enable if screen-wide and X position is 0"  },
+         { "auto horz and vert", "Enable if screen-wide and XY position is 0" },
+         { "above line 40",      "Enable above line 40"                       },
+         { "below line 40",      "Enable below line 40"                       },
+         { "above line 80",      "Enable above line 80"                       },
+         { "below line 80",      "Enable below line 80"                       },
+         { "above line 120",     "Enable above line 120"                      },
+         { "below line 120",     "Enable below line 120"                      },
+         { "above line 160",     "Enable above line 160"                      },
+         { "below line 160",     "Enable below line 160"                      },
+         { "above line 200",     "Enable above line 200"                      },
+         { "below line 200",     "Enable below line 200"                      },
+         { "crop edges",         "Hide lateral 8 pixels"                      },
+         { "auto crop edges",    "Hide lateral 8 black pixels"                },
+         { "off",                "Disable widescreen for this layer"          },
+         { "disable entirely",   "Hide layer entirely"                        },
+         { NULL, NULL },
+      },
+      "auto horz and vert"
+   },
+   {
+      "bsnes_mode7_wsbg4",
+      "Widescreen - Background Layer 4",
+      "Determines how Widescreen Mode should be applied to Background Layer 4.",
+      {
+         { "on",                 "enabled"                                    },
+         { "auto horizontal",    "Enable if screen-wide and X position is 0"  },
+         { "auto horz and vert", "Enable if screen-wide and XY position is 0" },
+         { "above line 40",      "Enable above line 40"                       },
+         { "below line 40",      "Enable below line 40"                       },
+         { "above line 80",      "Enable above line 80"                       },
+         { "below line 80",      "Enable below line 80"                       },
+         { "above line 120",     "Enable above line 120"                      },
+         { "below line 120",     "Enable below line 120"                      },
+         { "above line 160",     "Enable above line 160"                      },
+         { "below line 160",     "Enable below line 160"                      },
+         { "above line 200",     "Enable above line 200"                      },
+         { "below line 200",     "Enable below line 200"                      },
+         { "crop edges",         "Hide lateral 8 pixels"                      },
+         { "auto crop edges",    "Hide lateral 8 black pixels"                },
+         { "off",                "Disable widescreen for this layer"          },
+         { "disable entirely",   "Hide layer entirely"                        },
+         { NULL, NULL },
+      },
+      "auto horz and vert"
+   },
+   {
+      "bsnes_mode7_wsobj",
+      "Widescreen - Sprites",
+      "Adjusts how sprites and objects should be rendered when using Widescreen Mode.",
+      {
+         { "safe",             "Render when in safe area" },
+         { "unsafe",           "Render anywhere (unsafe)" },
+         { "clip",             "Clip at widescreen edges" },
+         { "disable entirely", "Hide sprites entirely"    },
+         { NULL, NULL },
+      },
+      "safe"
+   },
+   {
+      "bsnes_mode7_wsBgCol",
+      "Widescreen - Area Background Color",
+      "Specifies when to fill the backgrounds of the widescreen areas with the scanline background colors.",
+      {
+         { "auto",  "Fill if scene is widescreen" },
+         { "color", "Always fill"                 },
+         { "black", "Use black background"        },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
+      "bsnes_mode7_igwin",
+      "Widescreen - Ignore Window Effects",
+      "Defines which window effects should be ignored when using Widescreen Mode.",
+      {
+         { "outside",            "Only 'outside' effects"              },
+         { "outside and always", "Only 'outside' and 'always' effects" },
+         { "all",                "All window effects"                  },
+         { "none",               "disabled"                            },
+         { NULL, NULL },
+      },
+      "outside"
+   },
+   {
+      "bsnes_mode7_igwinx",
+      "Widescreen - Fallback X-Coordinate",
+      "Defines which fallback x-coordinate should be used when ignoring window effects in Widescreen Mode.",
+      {
+         { "40",  NULL           },
+         { "88",  NULL           },
+         { "128", "128 (Center)" },
+         { "168",  NULL          },
+         { "216",  NULL          },
+         { NULL, NULL },
+      },
+      "128"
+   },
+   {
+      "bsnes_mode7_wsMarker",
+      "Widescreen - Marker",
+      "Allows to highlight the edges of the widescreen areas in some ways.",
+      {
+         { "lines",  "Show lines at edges" },
+         { "darken", "Darken areas"        },
+         { "none",   "disabled"            },
+         { NULL, NULL },
+      },
+      "none"
+   },
+   {
+      "bsnes_mode7_wsMarkerAlpha",
+      "Widescreen - Marker Alpha",
+      "If widescreen markers are enabled, this option allows to specify their translucency.",
+      {
+         { "1/1",  NULL },
+         { "1/2",  NULL },
+         { "1/3",  NULL },
+         { "1/4",  NULL },
+         { "1/5",  NULL },
+         { "1/6",  NULL },
+         { "1/7",  NULL },
+         { "1/8",  NULL },
+         { "1/9",  NULL },
+         { "1/10", NULL },
+         { NULL, NULL },
+      },
+      "1/1"
+   },
+   {
+      "bsnes_mode7_strWin",
+      "Widescreen - Stretch Window",
+      "Extends windowing effects into the widescreen areas at the cost of precision. It is recommended to keep this option disabled, unless needed for widescreen hacks.",
+      {
+         { "ON",  "enabled"  },
+         { "OFF", "disabled" },
+      },
+      "OFF"
+   },
+
+   { NULL, NULL, NULL, {{0}}, NULL },
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
+   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,           /* RETRO_LANGUAGE_JAPANESE */
+   NULL,           /* RETRO_LANGUAGE_FRENCH */
+   NULL,           /* RETRO_LANGUAGE_SPANISH */
+   NULL,           /* RETRO_LANGUAGE_GERMAN */
+   NULL,           /* RETRO_LANGUAGE_ITALIAN */
+   NULL,           /* RETRO_LANGUAGE_DUTCH */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,           /* RETRO_LANGUAGE_KOREAN */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,           /* RETRO_LANGUAGE_POLISH */
+   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,           /* RETRO_LANGUAGE_ARABIC */
+   NULL,           /* RETRO_LANGUAGE_GREEK */
+   NULL,           /* RETRO_LANGUAGE_TURKISH */
+   NULL,           /* RETRO_LANGUAGE_SLOVAK */
+   NULL,           /* RETRO_LANGUAGE_PERSIAN */
+   NULL,           /* RETRO_LANGUAGE_HEBREW */
+   NULL,           /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,           /* RETRO_LANGUAGE_FINNISH */
+
+};
+#endif
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+{
+   unsigned version = 0;
+
+   if (!environ_cb)
+      return;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_intl core_options_intl;
+      unsigned language = 0;
+
+      core_options_intl.us    = option_defs_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = option_defs_intl[language];
+
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+#else
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+#endif
+   }
+   else
+   {
+      size_t i;
+      size_t num_options               = 0;
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine number of options */
+      for (;;)
+      {
+         if (!option_defs_us[num_options].key)
+            break;
+         num_options++;
+      }
+
+      /* Allocate arrays */
+      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
+      values_buf = (char **)calloc(num_options, sizeof(char *));
+
+      if (!variables || !values_buf)
+         goto error;
+
+      /* Copy parameters from option_defs_us array */
+      for (i = 0; i < num_options; i++)
+      {
+         const char *key                        = option_defs_us[i].key;
+         const char *desc                       = option_defs_us[i].desc;
+         const char *default_value              = option_defs_us[i].default_value;
+         struct retro_core_option_value *values = option_defs_us[i].values;
+         size_t buf_len                         = 3;
+         size_t default_index                   = 0;
+
+         values_buf[i] = NULL;
+
+         if (desc)
+         {
+            size_t num_values = 0;
+
+            /* Determine number of values */
+            for (;;)
+            {
+               if (!values[num_values].value)
+                  break;
+
+               /* Check if this is the default value */
+               if (default_value)
+                  if (strcmp(values[num_values].value, default_value) == 0)
+                     default_index = num_values;
+
+               buf_len += strlen(values[num_values].value);
+               num_values++;
+            }
+
+            /* Build values string */
+            if (num_values > 0)
+            {
+               size_t j;
+
+               buf_len += num_values - 1;
+               buf_len += strlen(desc);
+
+               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+               if (!values_buf[i])
+                  goto error;
+
+               strcpy(values_buf[i], desc);
+               strcat(values_buf[i], "; ");
+
+               /* Default value goes first */
+               strcat(values_buf[i], values[default_index].value);
+
+               /* Add remaining values */
+               for (j = 0; j < num_values; j++)
+               {
+                  if (j != default_index)
+                  {
+                     strcat(values_buf[i], "|");
+                     strcat(values_buf[i], values[j].value);
+                  }
+               }
+            }
+         }
+
+         variables[i].key   = key;
+         variables[i].value = values_buf[i];
+      }
+
+      /* Set variables */
+      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+
+error:
+
+      /* Clean up */
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bsnes/target-libretro/libretro_core_options_intl.h
+++ b/bsnes/target-libretro/libretro_core_options_intl.h
@@ -1,0 +1,90 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include "libretro.h"
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR updates the core options in the libretro implementation of bsnes-hd to version 1.3, allowing for descriptions of each option in the sublabels as well as translation support. See here for further reference: https://github.com/libretro/libretro-common/tree/master/samples/core_options

It is essentially a backport of what I had implemented for the up-to-date bsnes-libretro repo, as seen in https://github.com/libretro/bsnes-libretro/pull/4, coupled with a few changes and descriptions that were created from scratch for the widescreen-related settings and the other options that are specific to the bsnes-hd project.

Here is a recap of the main changes:

- Just like in the bsnes-libretro core, I refactored `libretro.cpp` inspired by the logic seen in the snes9x libretro core, mainly consisting of some edits to the `flush_variables()` function which was now renamed to `update_variables()`. This along with a few other changes implemented here were done to make the code more consistent with snes9x and bsnes.

- For "native" bsnes options the sublabel text was written based on the upstream descriptions, except for a few cases where the descriptions were either absent in the original code or needed to be adjusted for the libretro version.

- For the options that are specific to bsnes-hd, the sublabel descriptions were written based on information contained in the project readme, except for a few cases where a few adjustements were deemed necessary: https://github.com/DerKoun/bsnes-hd/blob/master/README.md

- Similarly to bsnes-libretro core, for certain options the "ON" and "OFF" values were previously hard-coded, so I kept this naming as-is for these values and just converted "ON" and "OFF" respectively into "enabled" and "disabled" inside `libretro_core_options.h`. This was done in order to preserve full backwards compatibility with the existing user configs and overrides, otherwise they would break;

- The name of the overscan option was slightly edited. Originally the name was "Show Overscan", but for the libretro core I made it look exactly as it is in snes9x and bsnes-libretro, showing up now as "Crop Overscan" with two possible values to make its behavior as clear as possible: the two values are either '12 pixels' (default) or '8 pixels'. That being said, the function has remained exactly the same internally, so backwards compatibility with the existing user configurations has remained intact.

- A slight reordering of the core options was performed both in `libretro.cpp` and `libretro_core_options.h` to mimic the order seen in upstream bsnes and bsnes-libretro, as well as achieve clearer consistency for the new settings. For example, now all the HD and Widescreen options are grouped close together at the bottom of the list, while the Color Adjustment settings (Luminance, Saturation and Gamma) are provided up top.

This was tested on Windows 10 x64 and everything seems to be working well. Here's a sample picture of how the core options look now:

![bsneshd-coreoptions](https://user-images.githubusercontent.com/17614150/122652960-ef221600-d141-11eb-9df2-2265c7dfb4bb.png)