### PR TITLE
Check result of reading _NET_WORKAREA before using

### DIFF
--- a/hiro/gtk/desktop.cpp
+++ b/hiro/gtk/desktop.cpp
@@ -26,16 +26,21 @@ auto pDesktop::workspace() -> Geometry {
   XlibAtom returnAtom;
 
   XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibTrue);
-  int result = XGetWindowProperty(
-    display, RootWindow(display, screen), netWorkarea, 0, 4, XlibFalse,
-    XInternAtom(display, "CARDINAL", XlibTrue), &returnAtom, &format, &items, &after, &data
-  );
 
-  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibTrue);
-  if(result == Success && returnAtom == cardinal && format == 32 && items == 4) {
-    unsigned long* workarea = (unsigned long*)data;
-    XCloseDisplay(display);
-    return {(int)workarea[0], (int)workarea[1], (int)workarea[2], (int)workarea[3]};
+  // Under certain window managers the _NET_WORKAREA atom is not set initially
+  if (netWorkarea != XlibNone) {
+
+    int result = XGetWindowProperty(
+      display, RootWindow(display, screen), netWorkarea, 0, 4, XlibFalse,
+      XInternAtom(display, "CARDINAL", XlibTrue), &returnAtom, &format, &items, &after, &data
+    );
+
+    XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibTrue);
+    if(result == Success && returnAtom == cardinal && format == 32 && items == 4) {
+      unsigned long* workarea = (unsigned long*)data;
+      XCloseDisplay(display);
+      return {(int)workarea[0], (int)workarea[1], (int)workarea[2], (int)workarea[3]};
+    }
   }
 
   XCloseDisplay(display);


### PR DESCRIPTION
It seems like not all window managers set _NET_WORKAREA. For example in
dwm this property isn't set when X first starts (but running certain
graphical applications such as firefox seem to cause the property to
become set). This change prevents a crash when bsnes is run in an
environment where _NET_WORKAREA has not been set.

Prior to this change, running bsnes as the first program under the dwm
window manager would result in the following error:

The program 'hiro' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadAtom (invalid Atom parameter)'.

This was the result of calling XGetWindowProperty with an Atom which
does not name a defined Atom.

## Reproducing/Testing

I can reliably reproduce the problem on an Archlinux machine and on a NixOS machine, both using dwm as their window manager. In a fresh X session, running bsnes consistently results in the aforementioned crash. After launching a graphical application such as firefox, bsnes starts without error.

I've tried reproducing the problem on a ubuntu machine with xfce4 as its wm. Launching bsnes in a fresh X session works. I assume this is because xfce4 implements _NET_WORKAREA.