### PR TITLE
Fix cheat codes not working when in uppercase

### DIFF
--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -765,6 +765,7 @@ auto decodeSNES(string& code) -> bool {
     for(uint n : code) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //decode
@@ -796,6 +797,7 @@ auto decodeSNES(string& code) -> bool {
     for(uint n : code) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //decode
@@ -813,6 +815,7 @@ auto decodeSNES(string& code) -> bool {
     for(uint n : nibbles) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //already in decoded form
@@ -826,6 +829,7 @@ auto decodeSNES(string& code) -> bool {
     for(uint n : nibbles) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //already in decoded form
@@ -850,6 +854,7 @@ auto decodeGB(string& code) -> bool {
     for(uint n : code) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     uint data = nibble(code, 0) << 4 | nibble(code, 1) << 0;
@@ -865,6 +870,7 @@ auto decodeGB(string& code) -> bool {
     for(uint n : code) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     uint data = nibble(code, 0) << 4 | nibble(code, 1) << 0;
@@ -882,6 +888,7 @@ auto decodeGB(string& code) -> bool {
     for(uint n : code) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //first two characters are the code type / VRAM bank, which is almost always 01.
@@ -902,6 +909,7 @@ auto decodeGB(string& code) -> bool {
     for(uint n : nibbles) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //already in decoded form
@@ -915,6 +923,7 @@ auto decodeGB(string& code) -> bool {
     for(uint n : nibbles) {
       if(n >= '0' && n <= '9') continue;
       if(n >= 'a' && n <= 'f') continue;
+      if(n >= 'A' && n <= 'F') continue;
       return false;
     }
     //already in decoded form


### PR DESCRIPTION
This fixes a longstanding issue where cheat codes would not work if they contained uppercase letters.