### PR TITLE
Makefile fix to enable build for "unix" and "unix-armv7-hardfloat-neon"

### DIFF
--- a/bsnes/GNUmakefile
+++ b/bsnes/GNUmakefile
@@ -34,7 +34,7 @@ else ifeq ($(platform),macos)
     flags += -fPIC
     options += -dynamiclib
   endif
-else ifneq ($(filter $(platform),linux bsd),)
+else ifneq ($(filter $(platform),linux bsd unix unix-armv7-hardfloat-neon),)
   ifeq ($(binary),application)
     options += -Wl,-export-dynamic
     options += -lX11 -lXext

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -22,7 +22,7 @@ objects := $(patsubst %,obj/%.o,$(objects))
 obj/libretro.o: target-libretro/libretro.cpp
 
 all: $(objects)
-ifeq ($(platform),linux)
+ifneq ($(filter $(platform),linux bsd unix unix-armv7-hardfloat-neon),)
 	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
 else ifeq ($(platform),windows)
 	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))


### PR DESCRIPTION
When building through libretro-super scripts, the platform value passed on to make command will not be "linux", instead it can be "unix" or "unix-armv7-hardfloat-neon". Added these options.

Related similar PR in libretro-bsnes: https://github.com/libretro/bsnes-libretro/pull/17