### PR TITLE
libretro: add RetroAchievements support (WRAM and SRAM)

### DIFF
--- a/bsnes/sfc/cartridge/cartridge.cpp
+++ b/bsnes/sfc/cartridge/cartridge.cpp
@@ -158,4 +158,12 @@ auto Cartridge::unload() -> void {
   ram.reset();
 }
 
+auto Cartridge::getSaveRAM() -> uint8_t* {
+  return ram.data();
+}
+
+auto Cartridge::getSaveRAMSize() -> size_t {
+  return ram.size();
+}
+
 }

--- a/bsnes/sfc/cartridge/cartridge.hpp
+++ b/bsnes/sfc/cartridge/cartridge.hpp
@@ -11,6 +11,8 @@ struct Cartridge {
   auto load() -> bool;
   auto save() -> void;
   auto unload() -> void;
+  auto getSaveRAM() -> uint8_t*;
+  auto getSaveRAMSize() -> size_t;
 
   auto serialize(serializer&) -> void;
 

--- a/bsnes/sfc/interface/interface.hpp
+++ b/bsnes/sfc/interface/interface.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 namespace SuperFamicom {
 
 struct ID {

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -32,6 +32,7 @@ static void audio_queue(int16_t left, int16_t right)
 }
 
 #include "program.cpp"
+#include <sfc/sfc.hpp>
 
 static string sgb_bios;
 static vector<string> cheatList;
@@ -1129,10 +1130,26 @@ unsigned retro_get_region()
 // Rely on higan to load and save SRAM until there is really compelling reason not to.
 void *retro_get_memory_data(unsigned id)
 {
-	return nullptr;
+	switch(id) 
+	{
+	case RETRO_MEMORY_SAVE_RAM:
+		return SuperFamicom::cartridge.getSaveRAM();
+	case RETRO_MEMORY_SYSTEM_RAM:
+		return SuperFamicom::cpu.wram;
+	}
+
+    return nullptr;
 }
 
 size_t retro_get_memory_size(unsigned id)
 {
-	return 0;
+	switch(id) 
+	{
+	case RETRO_MEMORY_SAVE_RAM:
+		return SuperFamicom::cartridge.getSaveRAMSize();
+	case RETRO_MEMORY_SYSTEM_RAM:
+		return 128 * 1024;
+	}
+
+    return 0;
 }


### PR DESCRIPTION
This add minimal support to allow retroachievements to work with bsnes-hd. 
I tested by loading a game, verifying that the achievements are loaded, and then triggered one to see if it works. 