### PR TITLE
Add webOS cross-compilation support, make openmp optional

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,12 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'  
 
+  #################################### MISC ##################################
+
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -201,3 +207,10 @@ libretro-build-libnx-aarch64:
     - mv retroarch_switch.nro ../${CORENAME}_libretro_libnx.nro
     - mv retroarch_switch.elf ../${CORENAME}_libretro_libnx.elf
     - cd ../
+
+#################################### MISC ##################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs

--- a/bsnes/GNUmakefile
+++ b/bsnes/GNUmakefile
@@ -1,7 +1,7 @@
 target ?= bsnes
 binary ?= application
 build := performance
-openmp := true
+openmp ?= true
 local := false
 flags += -I. -I..
 

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -1,7 +1,13 @@
 name := bsnes_libretro
 local := false
-openmp := true
+openmp ?= true
 flags += -Wno-narrowing -Wno-multichar -g -fPIC
+
+ifeq ($(openmp),true)
+  openmp_libs := -lgomp
+else
+  openmp_libs :=
+endif
 
 ifeq ($(platform), ios-arm64)
 	flags += -fPIC -miphoneos-version-min=11.0 -Wno-error=implicit-function-declaration -DHAVE_POSIX_MEMALIGN
@@ -22,10 +28,10 @@ objects := $(patsubst %,obj/%.o,$(objects))
 obj/libretro.o: target-libretro/libretro.cpp
 
 all: $(objects)
-ifeq ($(platform),linux)
-	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
+ifneq ($(filter $(platform),linux unix),)
+	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T $(openmp_libs) -Wl,-Bdynamic $(options))
 else ifeq ($(platform),windows)
-	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
+	$(strip $(compiler) -o out/bsnes_hd_beta_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T $(openmp_libs) -Wl,-Bdynamic $(options))
 else ifeq ($(platform),libnx)
 	$(strip $(AR) rcs out/bsnes_hd_beta_libretro_libnx.a $(objects))
 else ifeq ($(platform),macos)

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -83,6 +83,13 @@ ifeq ($(compiler),)
   endif
 endif
 
+# cross compilation
+ifneq (,$(findstring webos,$(CROSS_COMPILE)))
+  ifeq (,$(wildcard $(STAGING_DIR)/usr/lib/libgomp.so))
+    openmp = false
+  endif
+endif
+
 # build optimization levels
 ifeq ($(build),debug)
   flags += -Og -g -DBUILD_DEBUG


### PR DESCRIPTION
1. openmp is now optional for libretro as it was getting overridden
2. adds unix as a platform as this is what libretro-super sets
3. add cross compilation check for webOS. openMP is only supported on webOS 3.8.0, so I've added a check for the existence of openMP in the toolchain