### PR TITLE
Make perspective-correction at 1x resolution usable before using a higher resolution

### DIFF
--- a/bsnes/sfc/ppu-fast/line.cpp
+++ b/bsnes/sfc/ppu-fast/line.cpp
@@ -72,7 +72,7 @@ auto PPU::Line::flush() -> void {
   }
 
   if(Line::count) {
-    if(ppu.hdScale() > 1) cacheMode7HD();
+    if(ppu.hdScale()) cacheMode7HD();
     #pragma omp parallel for if(Line::count >= 8)
     for(uint y = 0; y < Line::count; y++) {
       if(ppu.deinterlace()) {


### PR DESCRIPTION
Perspective-correction does not work properly until `cacheMode7HD()` has been used; which does happen while the scale-setting is set to 2x or higher, but not while it is set to "1x 224p" (`ppu.hdScale() = 1`) or "disable" (`ppu.hdScale() = 0`).
"1x 224p" is for using enhancements at the original resolution, so using `cacheMode7HD()` is also necessary then, so that perspective-correction can work properly.

<details><summary>Image-comparison (F-Zero)</summary>

Without this change:
<img width="256" height="224" alt="F-Zero at 1x resolution without perspective-correction" src="https://github.com/user-attachments/assets/7cf918a3-99c4-4502-89ee-7dde5a4a84ee" />

With this change:
<img width="256" height="224" alt="F-Zero at 1x resolution with perspective-correction" src="https://github.com/user-attachments/assets/81a084c3-1769-4354-ba34-3e59fb5ddc9f" />

</details>

It may be necessary to restart bsnes-hd after changing the scale-setting to 1x, for the issue, that this change solves, to happen.